### PR TITLE
fix eslint error, add watch flag and add start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "npm run build && npm run storybook",
     "build": "vite build",
+    "watch": "vite build --watch",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "npm run build && storybook build -o storybook",
     "test-storybook": "test-storybook",
+    "start": "npm run watch & npm run storybook",
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "stylelint": "stylelint './components/**/*.css'"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,14 +36,14 @@ export default defineConfig({
       targets: [
         {
           src: './source/**/*.{png,jpg,jpeg,svg,webp}',
-          dest: 'images'
-        }
-      ]
-    })
+          dest: 'images',
+        },
+      ],
+    }),
   ],
   build: {
     emptyOutDir: true,
-    outDir: "./dist",
+    outDir: './dist',
     rollupOptions: {
       // Recursively globbing through all CSS and JS files
       // within the source directory.


### PR DESCRIPTION
- Fix eslint error
- Add `--watch` flag to have Vite listen for linting
- Add `start` command to run both Vite and Storybook while linting
- Modify storybook-build command to output to `storybook` folder